### PR TITLE
Adding array of strings in root (nested functionality)

### DIFF
--- a/schemas/WebpackOptions.json
+++ b/schemas/WebpackOptions.json
@@ -499,7 +499,17 @@
               "properties": {
                 "root": {
                   "description": "Name of the property exposed globally by a UMD library",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
                 },
                 "amd": {
                   "description": "Name of the exposed AMD library in the UMD",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fix in schema

**Did you add tests for your changes?**

Not needed

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Webpack output.library.root accepts array of strings, however the schema only accepts string. Many projects depend on nesting externals under a namespace. This will eliminate the need to create custom plugins so that we can nest modules under the root name. FYI @ibezkrovnyi

For example below, -->  Webpack will output `root['my-global-root']['my-app-name']`.
```javascript
output: {
  library: {
    /* 
     schema throws an error as type is only string but
     webpack itself can accept array of strings as well
   */
    root: ['my-global-root', 'my-app-name'], 
    amd: 'my-app-name',
    commonjs: 'my-app-name'
  },
  libraryTarget: 'umd'
}
```

**Does this PR introduce a breaking change?**

No

**Other information**
